### PR TITLE
Manifest: Remove x-checker-data config

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -142,9 +142,6 @@ modules:
           - zypak-wrapper /app/bin/heroic/heroic "$@"
 
       - type: file
-        x-checker-data:
-          type: electron-updater
-          url: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v2.3.10/latest-linux.yml
         url: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v2.3.10/Heroic-2.3.10.AppImage
         sha512: de3564d382bbb831f84fa61ad17cef806d6052bf79fee8c4afaf267cd7e8d176f2a9bafc1c9632bbb3b73069d248d9b5c6a1a5901cfca78531f5f038b207c6ab
 


### PR DESCRIPTION
Not needed as updates are manually pushed by the maintainer.