### PR TITLE
Fix incompatibility with xdg-open

### DIFF
--- a/com.heroicgameslauncher.hgl.desktop
+++ b/com.heroicgameslauncher.hgl.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Heroic Games Launcher
-Exec=heroic-run
+Exec=heroic-run %u
 Terminal=false
 Type=Application
 Icon=com.heroicgameslauncher.hgl


### PR DESCRIPTION
The `.desktop` file was missing the [`%u`](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) field code, making every `xdg-open heroic://launch/Game` call ignored.  
Applying it solved the issue on Gnome, but should work on every xdg compliant environment.
I tested it on Fedora 37 with Gnome 43.2.
