### PR TITLE
Add OBSVkCapture to path

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -19,7 +19,7 @@ finish-args:
   - --allow=devel
   - --allow=multiarch
   - --device=all
-  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin:/app/bin/heroic/resources/app.asar.unpacked/build/bin/linux
+  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin:/app/bin/heroic/resources/app.asar.unpacked/build/bin/linux
   - --filesystem=xdg-data/lutris:rw
   - --filesystem=xdg-data/Steam:rw
   - --filesystem=xdg-data/applications:rw


### PR DESCRIPTION
This adds [OBSVKCapture ](https://github.com/nowrep/obs-vkcapture) to the path so it can be easily used in Heroic flatpak. Bottles [does this as well](https://github.com/flathub/com.usebottles.bottles/blob/f6550fc0d2099e7fc43b3ff819c8e8e3edba3007/com.usebottles.bottles.yml#L21).

![obs-gamecapture](https://user-images.githubusercontent.com/37268985/211162906-fa66a53e-08e6-4f2d-a1d5-ce6949b71624.png)
