### PR TITLE
Fix tray icon on KDE wayland

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -36,6 +36,7 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.Notifications
+  - --own-name=org.kde.*
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:


### PR DESCRIPTION
electron 22 added dbus menus, which requires this new permission