### PR TITLE
Add libcaca

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -303,8 +303,13 @@ modules:
       - --disable-static
     sources: &libcaca_sources
       - type: archive
-        url: http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz
-        sha256: 128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4
+        url: https://github.com/cacalabs/libcaca/releases/download/v0.99.beta20/libcaca-0.99.beta20.tar.gz
+        sha256: 8ad74babc63bf665b0b2378d95b4da65b7493c11bd9f3ac600517085b0c4acf2
+        x-checker-data:
+          type: anitya
+          project-id: 7952
+          stable-only: false
+          url-template: https://github.com/cacalabs/libcaca/releases/download/v$version/libcaca-$version.tar.gz
 
   - name: libcaca_32bit
     build-options:

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -292,3 +292,25 @@ modules:
       - type: patch
         path: patches/aria2/working-build.patch
   #END --- Winetricks Deps --
+  #START --- Native games libs -- 
+  - shared-modules/glu/glu-9.json
+
+  - name: libcaca
+    config-opts: &libcaca_config_opts
+      --disable-doc
+      --disable-python
+      --disable-ruby
+      --disable-static
+    sources: &libcaca_sources
+      - type: archive
+        url: http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz
+        sha256: 128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4
+
+  - name: libcaca_32bit
+    build-options:
+      arch:
+        x86_64: *compat_i386_opts
+    config-opts: *libcaca_config_opts
+    sources: *libcaca_sources
+
+  #END --- Native games libs --

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -297,10 +297,10 @@ modules:
 
   - name: libcaca
     config-opts: &libcaca_config_opts
-      --disable-doc
-      --disable-python
-      --disable-ruby
-      --disable-static
+      - --disable-doc
+      - --disable-python
+      - --disable-ruby
+      - --disable-static
     sources: &libcaca_sources
       - type: archive
         url: http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz


### PR DESCRIPTION
This is one of DOSBox dependencies, unless we support using DOSBox installed by user instead of one bundled with GOG games, we need this