### PR TITLE
Drop `own-name=org.kde.*`

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -41,7 +41,7 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.Notifications
-  - --own-name=org.kde.*
+  - --talk-name=org.kde.StatusNotifierWatcher
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -168,6 +168,7 @@ modules:
           - for i in {0..9}; do
           - test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
           - done
+          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
           - zypak-wrapper /app/bin/heroic/heroic "$@"
 
       - type: file


### PR DESCRIPTION
Solves https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2509

The own-name currently prevents the icon to show up.

In my testing adding `org.kde.StatusNotifierWatcher` doesn't seem to do anything extra, I think it can be removed. I tested on GNOME and KDE both but I'm not familiar with KDE. Please test that.

cc @Etaash-mathamsetty