### PR TITLE
Enable org.freedesktop.Flatpak talk

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -40,6 +40,7 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.Flatpak
   - --own-name=org.kde.*
 
 add-extensions:


### PR DESCRIPTION
this will allow to detect native versions of ScummVM to use instead of Windows versions ran through wine. This functionality will be further extended to DOSBox too