### PR TITLE
Add `/mnt/` to the filesystem permissions

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -30,6 +30,8 @@ finish-args:
   - --filesystem=xdg-desktop
   # should fix access to SD card on the deck
   - --filesystem=/run/media
+  # There are still quite a few users using /mnt/ for external drives
+  - --filesystem=/mnt
   # should fix steamdeck controler navigation
   - --filesystem=/run/udev:ro
   # should fix discord rich presence


### PR DESCRIPTION
`/mnt` is, by some users, used to mount external drives
We already have `/run/media` in the list for this same reason, and we occasionally get users with issues about this