### PR TITLE
[Fix] Specify paths to Lutris, Steam, and applications explicitly

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -20,9 +20,9 @@ finish-args:
   - --allow=multiarch
   - --device=all
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin:/usr/lib/extensions/vulkan/gamescope/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin:/app/bin/heroic/resources/app.asar.unpacked/build/bin/linux
-  - --filesystem=xdg-data/lutris:rw
-  - --filesystem=xdg-data/Steam:rw
-  - --filesystem=xdg-data/applications:rw
+  - --filesystem=~/.local/share/lutris:rw
+  - --filesystem=~/.steam/steam:rw
+  - --filesystem=~/.local/share/applications:rw
   - --filesystem=~/.steam:rw
   - --filesystem=~/Games/Heroic:create
   - --filesystem=~/.var/app/com.valvesoftware.Steam:rw


### PR DESCRIPTION
We are actually using these paths explicitly (see [here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/f9cfbc06b736876acb00e323999a6e2691d305d9/src/backend/utils/compatibility_layers.ts#L135), [here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/f9cfbc06b736876acb00e323999a6e2691d305d9/src/backend/constants.ts#L173), and [here](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/f9cfbc06b736876acb00e323999a6e2691d305d9/src/backend/shortcuts/shortcuts/shortcuts.ts#L154)). Additionally, this resolves the "finish-args-unnecessary-xdg-data-access" error from the Build Linter.