### PR TITLE
remove mangohud filesystem config

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -29,7 +29,6 @@ finish-args:
   - --filesystem=~/.steam:rw
   - --filesystem=~/Games/Heroic:create
   - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
-  - --filesystem=~/.config/MangoHud:ro
   - --filesystem=xdg-documents
   - --filesystem=xdg-desktop
   - --filesystem=xdg-run/gamescope-0:rw

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -1,9 +1,9 @@
 id: com.heroicgameslauncher.hgl
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '23.08'
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '23.08'
 command: heroic-run
 separate-locales: false
 
@@ -59,17 +59,17 @@ finish-args:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '24.08'
+    version: '23.08'
 
   org.freedesktop.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: '24.08'
+    version: '23.08'
     no-autodownload: true
 
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: '1.4'
-    versions: 24.08;1.4
+    versions: 23.08;1.4
     subdirectories: true
     no-autodownload: true
     autodelete: false
@@ -89,8 +89,8 @@ add-extensions:
 
   org.freedesktop.Platform.VAAPI.Intel.i386:
     directory: lib/i386-linux-gnu/dri/intel-vaapi-driver
-    version: '24.08'
-    versions: '24.08'
+    version: '23.08'
+    versions: '23.08'
     autodelete: false
     no-autodownload: true
     add-ld-path: lib


### PR DESCRIPTION
flatpak linter apparently doesn't like it when it's corrected, and it doesn't work in the current form, so we get rid of it