### PR TITLE
Use env to enable wayland by default

### DIFF
--- a/com.heroicgameslauncher.hgl.desktop
+++ b/com.heroicgameslauncher.hgl.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Heroic Games Launcher
-Exec=heroic-run --ozone-platform-hint=auto %u
+Exec=heroic-run %u
 Terminal=false
 Type=Application
 Icon=com.heroicgameslauncher.hgl

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -55,6 +55,8 @@ finish-args:
   # wine uses this for disk drives (mountmgr.sys)
   - --system-talk-name=org.freedesktop.UDisks2
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
+  # use wayland by default
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:


### PR DESCRIPTION
quick test shows that the original way never worked (having it = x11, not having it = x11)