### PR TITLE
Fix Custom Mouse Cursors and Size

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -55,6 +55,8 @@ finish-args:
   # wine uses this for disk drives (mountmgr.sys)
   - --system-talk-name=org.freedesktop.UDisks2
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
+  # Ensure that custom mouse cursors are used
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:


### PR DESCRIPTION
Fixes #177 by adding the environment variable necessary for the Flatpak to use the mouse cursors defined by the user.