### PR TITLE
Unbreak 32-bit Vulkan support on NVIDIA

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -55,6 +55,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   # wine uses this for disk drives (mountmgr.sys)
   - --system-talk-name=org.freedesktop.UDisks2
+  - --env=XDG_CONFIG_DIRS=/app/etc/xdg:/etc/xdg:/usr/lib/x86_64-linux-gnu/GL # The last path here enables Vulkan support for 32-bit applications on NVIDIA GPUs.
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
   # Ensure that custom mouse cursors are used
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
A [recent change](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/commit/d55b7cb0e5269b5bd4b0d86ac8df2f77966451ce) in the NVIDIA GL extension stopped including the Vulkan ICD file in the GL32 extension, in order to prevent the Vulkan Loader (`libvulkan.so`) from incorrectly [reporting duplicated GPUs](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/112) to Vulkan apps.

However, that fix ended up [breaking 32-bit Vulkan support](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/342) for some multiarch apps (such as this one).

One way to fix this, is by modifying `XDG_CONFIG_DIRS` to include the path where the NVIDIA ICD file (`nvidia_icd.json`) is, which in turn helps the 32-bit Vulkan Loader [find it](https://vulkan.lunarg.com/doc/view/1.4.309.0/linux/LoaderDriverInterface.html#driver-discovery-on-linux).

Steam has been pretty much [this same solution](https://github.com/flathub/com.valvesoftware.Steam/commit/ae87f47cd15969d5d3019088b4e89341b9a2fbe7) for almost 5 years.

---

I tested this by running [Geometry Wars: Retro Evolved](https://store.steampowered.com/app/8400/Geometry_Wars_Retro_Evolved/) (32-bit, D3D9) in Heroic with `VK_LOADER_DEBUG=driver` set for useful debugging output.

- Log file **before** this change: [geometry-wars-bad.log](https://gist.githubusercontent.com/guihkx/b3922d0764f8b7671c5523c269feedf8/raw/bd3f1174708b8a26d9fdf5c2c6cc3af93b638c51/geometry-wars-bad.log)
- Log file **after** this change: [geometry-wars-good.log](https://gist.githubusercontent.com/guihkx/0035ad0a2b2e8e32f330da25829c962d/raw/670d4482280979adc142400fe4c769873cb8031a/geometry-wars-good.log)