### PR TITLE
autoprune old gpu drivers

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -112,6 +112,7 @@ add-extensions:
     merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
     download-if: active-gl-driver
     enable-if: active-gl-driver
+    autoprune-unless: active-gl-driver
 
   x-compat-i386-opts: &compat_i386_opts
     prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig


### PR DESCRIPTION
This should stop heroic from not allowing old NVIDIA drivers to be cleaned up after updating