### PR TITLE
feat: Add TiMidity++ and FluidR3 for MIDI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder/

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -390,50 +390,51 @@ modules:
         dest-filename: heroic-midi-wrapper
         contents: |
           #!/bin/bash
-        
+
           detect_midi_game() {
             local game_dir="$1"
-          
-            if [[ ! -d "$game_dir" ]]; then
-              return 1  # No game directory found
-            fi
-          
+            if [[ ! -d "$game_dir" ]]; then return 1; fi
             if find "$game_dir" -iname "*.mid" -o -iname "*.midi" | grep -q .; then
               echo "Found MIDI files in game directory"
               return 0
             fi
-          
             if find "$game_dir" -name "*.cfg" -o -name "*.conf" -o -name "*.ini" | \
-               xargs grep -l -i "midi\|timidity\|mpu-401\|sound.*midi" 2>/dev/null | grep -q .; then
-              echo "Found MIDI configuration references"
+              xargs grep -l -i "midi\|timidity\|mpu-401\|sound.*midi" 2>/dev/null | grep -q .; then
+              echo "Found MIDI configuration references"  
               return 0
             fi
-          
-            if find "$game_dir" -name "*.exe" | \
-               xargs grep -l "MIDI\|MPU\|SoundBlaster" 2>/dev/null | grep -q .; then
-              echo "Found MIDI-related strings in executables"
-              return 0
-            fi
-          
-            return 1  # No MIDI indicators found
+            return 1
           }
-        
+
           start_timidity() {
             if ! pgrep -f "timidity.*-iA" > /dev/null; then
               echo "Auto-starting TiMidity++ for MIDI-enabled game"
               /app/bin/timidity -iA &
+              TIMIDITY_PID=$!
               sleep 2
               echo "TiMidity++ ready for MIDI playback"
             fi
           }
-        
+
+          cleanup() {
+            if [[ -n "$TIMIDITY_PID" ]] && kill -0 "$TIMIDITY_PID" 2>/dev/null; then
+              echo "Stopping TiMidity++ (PID: $TIMIDITY_PID)"
+              kill "$TIMIDITY_PID" 2>/dev/null
+            fi
+          }
+
+          trap cleanup EXIT INT TERM
+
           if [[ -n "$STEAM_COMPAT_INSTALL_PATH" ]]; then
             if detect_midi_game "$STEAM_COMPAT_INSTALL_PATH"; then
               start_timidity
             fi
           fi
-        
-          exec /app/bin/gamemoderun-original "$@"
+
+          /app/bin/gamemoderun-original "$@" &
+          GAME_PID=$!
+
+          wait $GAME_PID
           GAME_EXIT_CODE=$?
 
           cleanup

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -386,42 +386,97 @@ modules:
           opt EFreverb=d
       - type: patch
         path: patches/0001-timidity-fix-missing-includes.patch
+      - type: inline
+        dest-filename: heroic-midi-wrapper
+        contents: |
+          #!/bin/bash
+        
+          detect_midi_game() {
+            local game_dir="$1"
+          
+            if [[ ! -d "$game_dir" ]]; then
+              return 1  # No game directory found
+            fi
+          
+            if find "$game_dir" -iname "*.mid" -o -iname "*.midi" | grep -q .; then
+              echo "Found MIDI files in game directory"
+              return 0
+            fi
+          
+            if find "$game_dir" -name "*.cfg" -o -name "*.conf" -o -name "*.ini" | \
+               xargs grep -l -i "midi\|timidity\|mpu-401\|sound.*midi" 2>/dev/null | grep -q .; then
+              echo "Found MIDI configuration references"
+              return 0
+            fi
+          
+            if find "$game_dir" -name "*.exe" | \
+               xargs grep -l "MIDI\|MPU\|SoundBlaster" 2>/dev/null | grep -q .; then
+              echo "Found MIDI-related strings in executables"
+              return 0
+            fi
+          
+            return 1  # No MIDI indicators found
+          }
+        
+          start_timidity() {
+            if ! pgrep -f "timidity.*-iA" > /dev/null; then
+              echo "Auto-starting TiMidity++ for MIDI-enabled game"
+              /app/bin/timidity -iA &
+              sleep 2
+              echo "TiMidity++ ready for MIDI playback"
+            fi
+          }
+        
+          if [[ -n "$STEAM_COMPAT_INSTALL_PATH" ]]; then
+            if detect_midi_game "$STEAM_COMPAT_INSTALL_PATH"; then
+              start_timidity
+            fi
+          fi
+        
+          exec /app/bin/gamemoderun-original "$@"
+          GAME_EXIT_CODE=$?
+
+          cleanup
+          exit $GAME_EXIT_CODE
+       
     post-install:
-      - install -d ${FLATPAK_DEST}/share/timidity
-      - install -Dm644 custom-timidity.cfg ${FLATPAK_DEST}/share/timidity/timidity.cfg
-      
+        - install -d ${FLATPAK_DEST}/share/timidity
+        - install -Dm644 custom-timidity.cfg ${FLATPAK_DEST}/share/timidity/timidity.cfg
+        - mv ${FLATPAK_DEST}/bin/gamemoderun ${FLATPAK_DEST}/bin/gamemoderun-original
+        - install -Dm755 heroic-midi-wrapper ${FLATPAK_DEST}/bin/gamemoderun      
+
       # Copy ALSA configuration files
-      - install -d ${FLATPAK_DEST}/share/alsa
-      - cp -ar /usr/share/alsa/* ${FLATPAK_DEST}/share/alsa/
-      - install -d ${FLATPAK_DEST}/etc
-      - ln -sf /app/share/alsa/alsa.conf ${FLATPAK_DEST}/etc/asound.conf
+        - install -d ${FLATPAK_DEST}/share/alsa
+        - cp -ar /usr/share/alsa/* ${FLATPAK_DEST}/share/alsa/
+        - install -d ${FLATPAK_DEST}/etc
+        - ln -sf /app/share/alsa/alsa.conf ${FLATPAK_DEST}/etc/asound.conf
 
-      # Copy ALSA plugins (both x86_62 and i386 for multilib support)
-      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib
-      - cp -a /usr/lib/x86_64-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib/
-      - install -d ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib
-      - cp -a /usr/lib/i386-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib/
+        # Copy ALSA plugins (both x86_62 and i386 for multilib support)
+        - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib
+        - cp -a /usr/lib/x86_64-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib/
+        - install -d ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib
+        - cp -a /usr/lib/i386-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib/
 
-      # Copy PulseAudio client libraries
-      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu
-      - cp -a /usr/lib/x86_64-linux-gnu/libpulse.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libsndfile.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libogg.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libvorbis*.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libFLAC.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libopus.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio
-      - cp -a /usr/lib/x86_64-linux-gnu/pulseaudio/libpulsecommon*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio/
+        # Copy PulseAudio client libraries
+        - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu
+        - cp -a /usr/lib/x86_64-linux-gnu/libpulse.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+        - cp -a /usr/lib/x86_64-linux-gnu/libsndfile.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+        - cp -a /usr/lib/x86_64-linux-gnu/libogg.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+        - cp -a /usr/lib/x86_64-linux-gnu/libvorbis*.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+        - cp -a /usr/lib/x86_64-linux-gnu/libFLAC.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+        - cp -a /usr/lib/x86_64-linux-gnu/libopus.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+        - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio
+        - cp -a /usr/lib/x86_64-linux-gnu/pulseaudio/libpulsecommon*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio/
 
   - name: fluidr3-soundfont
     buildsystem: simple
     build-commands:
-      - tar -xzf fluid-soundfont.tar.gz -C . "FluidR3 GM2-2.SF2"
-      - install -d ${FLATPAK_DEST}/share/soundfonts
-      - install -Dm644 "FluidR3 GM2-2.SF2" ${FLATPAK_DEST}/share/soundfonts/FluidR3_GM.sf2
-      - echo "soundfont FluidR3_GM.sf2" > fluid3gm.cfg
-      - install -Dm644 fluid3gm.cfg ${FLATPAK_DEST}/share/soundfonts/fluid3gm.cfg
+        - tar -xzf fluid-soundfont.tar.gz -C . "FluidR3 GM2-2.SF2"
+        - install -d ${FLATPAK_DEST}/share/soundfonts
+        - install -Dm644 "FluidR3 GM2-2.SF2" ${FLATPAK_DEST}/share/soundfonts/FluidR3_GM.sf2
+        - echo "soundfont FluidR3_GM.sf2" > fluid3gm.cfg
+        - install -Dm644 fluid3gm.cfg ${FLATPAK_DEST}/share/soundfonts/fluid3gm.cfg
     sources:
-      - type: file
-        url: https://ftp.osuosl.org/pub/musescore/soundfont/fluid-soundfont.tar.gz
-        sha256: c815769e44d86f1507b946a6c48c997c7f650699aea1ec4b11ba66e3415c26b9
+        - type: file
+          url: https://ftp.osuosl.org/pub/musescore/soundfont/fluid-soundfont.tar.gz
+          sha256: c815769e44d86f1507b946a6c48c997c7f650699aea1ec4b11ba66e3415c26b9

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -362,3 +362,41 @@ modules:
         x86_64: *compat_i386_opts
     sources: *libbsd_sources
   #END --- Winetricks Deps ---
+
+  # --- MIDI Support (TiMidity++ with FluidR3_GM) ---
+  - name: timidity
+    buildsystem: autotools
+    config-opts:
+      - --enable-alsa
+      - --enable-alsaseq
+    cleanup: ["*.la", "*.a", "/include", "/lib/pkgconfig", "/share/man", "/share/doc"]
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/timidity/files/TiMidity++/TiMidity++-2.15.0/TiMidity++-2.15.0.tar.bz2
+        sha256: 161fc0395af16b51f7117ad007c3e434c825a308fa29ad44b626ee8f9bb1c8f5
+      - type: inline
+        dest-filename: custom-timidity.cfg
+        contents: |
+          dir /app/share/soundfonts
+          source /app/share/soundfonts/fluid3gm.cfg
+          opt EFresamp=d
+          opt EFvlpf=d
+          opt EFreverb=d
+      - type: patch
+        path: patches/0001-timidity-fix-missing-includes.patch
+    post-install:
+      - install -d ${FLATPAK_DEST}/share/timidity
+      - install -Dm644 custom-timidity.cfg ${FLATPAK_DEST}/share/timidity/timidity.cfg
+
+  - name: fluidr3-soundfont
+    buildsystem: simple
+    build-commands:
+      - tar -xzf fluid-soundfont.tar.gz -C . "FluidR3 GM2-2.SF2"
+      - install -d ${FLATPAK_DEST}/share/soundfonts
+      - install -Dm644 "FluidR3 GM2-2.SF2" ${FLATPAK_DEST}/share/soundfonts/FluidR3_GM.sf2
+      - echo "soundfont FluidR3_GM.sf2" > fluid3gm.cfg
+      - install -Dm644 fluid3gm.cfg ${FLATPAK_DEST}/share/soundfonts/fluid3gm.cfg
+    sources:
+      - type: file
+        url: https://ftp.osuosl.org/pub/musescore/soundfont/fluid-soundfont.tar.gz
+        sha256: c815769e44d86f1507b946a6c48c997c7f650699aea1ec4b11ba66e3415c26b9

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -369,6 +369,8 @@ modules:
     config-opts:
       - --enable-alsa
       - --enable-alsaseq
+      - --enable-audio=alsa,pulse
+      - --enable-interface=server,alsaseq
     cleanup: ["*.la", "*.a", "/include", "/lib/pkgconfig", "/share/man", "/share/doc"]
     sources:
       - type: archive
@@ -387,6 +389,29 @@ modules:
     post-install:
       - install -d ${FLATPAK_DEST}/share/timidity
       - install -Dm644 custom-timidity.cfg ${FLATPAK_DEST}/share/timidity/timidity.cfg
+      
+      # Copy ALSA configuration files
+      - install -d ${FLATPAK_DEST}/share/alsa
+      - cp -ar /usr/share/alsa/* ${FLATPAK_DEST}/share/alsa/
+      - install -d ${FLATPAK_DEST}/etc
+      - ln -sf /app/share/alsa/alsa.conf ${FLATPAK_DEST}/etc/asound.conf
+
+      # Copy ALSA plugins (both x86_62 and i386 for multilib support)
+      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib
+      - cp -a /usr/lib/x86_64-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib/
+      - install -d ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib
+      - cp -a /usr/lib/i386-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib/
+
+      # Copy PulseAudio client libraries
+      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu
+      - cp -a /usr/lib/x86_64-linux-gnu/libpulse.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libsndfile.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libogg.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libvorbis*.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libFLAC.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libopus.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio
+      - cp -a /usr/lib/x86_64-linux-gnu/pulseaudio/libpulsecommon*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio/
 
   - name: fluidr3-soundfont
     buildsystem: simple

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -366,16 +366,22 @@ modules:
   # --- MIDI Support (TiMidity++ with FluidR3_GM) ---
   - name: timidity
     buildsystem: autotools
+    build-options:
+      cflags: "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration"
     config-opts:
       - --enable-alsa
       - --enable-alsaseq
       - --enable-audio=alsa,pulse
       - --enable-interface=server,alsaseq
     cleanup: ["*.la", "*.a", "/include", "/lib/pkgconfig", "/share/man", "/share/doc"]
+
     sources:
       - type: archive
         url: https://sourceforge.net/projects/timidity/files/TiMidity++/TiMidity++-2.15.0/TiMidity++-2.15.0.tar.bz2
         sha256: 161fc0395af16b51f7117ad007c3e434c825a308fa29ad44b626ee8f9bb1c8f5
+      - type: shell
+        commands:
+          - sed -i '/int line_fold();/d' utils/nkflib.c
       - type: inline
         dest-filename: custom-timidity.cfg
         contents: |

--- a/patches/0001-timidity-fix-missing-includes.patch
+++ b/patches/0001-timidity-fix-missing-includes.patch
@@ -1,0 +1,83 @@
+--- a/timidity/au_a.c
++++ b/timidity/au_a.c
+@@ -62,6 +62,11 @@
+ #include "instrum.h"
+ #include "playmidi.h"
+ #include "readmidi.h"
++#include <string.h>
++#include <ctype.h>
++#include <stdlib.h>
++#include <errno.h> /* For strerror and errno */
++
+ 
+ static int open_output(void); /* 0=success, 1=warning, -1=fatal error */
+ static void close_output(void);
+--- a/timidity/freq.c
++++ b/timidity/freq.c
+@@ -30,6 +30,7 @@
+ #include "instrum.h"
+ #include "freq.h"
+ #include "fft4g.h"
++#include <string.h> /* For memset, memcpy */
+ 
+ float *floatdata, *magdata, *prunemagdata;
+ int *ip;
+--- a/timidity/output.c
++++ b/timidity/output.c
+@@ -37,6 +37,9 @@
+ #include "common.h"
+ #include "output.h"
+ #include "audio_cnv.h"
++#include <string.h>
++#include <ctype.h>
++/* stdlib.h might also be needed if safe_malloc is not defined elsewhere or for free() if used */
+ 
+ /* For select() */
+ #ifdef HAVE_SYS_SELECT_H
+--- a/timidity/quantity.c
++++ b/timidity/quantity.c
+@@ -39,6 +39,7 @@
+ #include "common.h"
+ #include "instrum.h"
+ #include "quantity.h"
++#include <string.h>
+ 
+ /* Unit table */
+ typedef struct _unit_name {
+--- a/timidity/raw_a.c
++++ b/timidity/raw_a.c
+@@ -62,6 +62,11 @@
+ #include "instrum.h"
+ #include "playmidi.h"
+ #include "readmidi.h"
++#include <string.h>
++#include <ctype.h>
++#include <stdlib.h>
++#include <errno.h> /* For strerror and errno */
++
+ 
+ static int open_output(void); /* 0=success, 1=warning, -1=fatal error */
+ static void close_output(void);
+--- a/timidity/timidity.c
++++ b/timidity/timidity.c
+@@ -94,6 +94,7 @@
+ #include "filter.h"
+ #include "resample.h"
+ #include "rtsyn.h"
++#include <ctype.h>
+ 
+ #ifdef HAVE_LOCALE_H
+ #include <locale.h>
+--- a/timidity/wave_a.c
++++ b/timidity/wave_a.c
+@@ -59,6 +59,10 @@
+ #include "instrum.h"
+ #include "playmidi.h"
+ #include "readmidi.h"
++#include <string.h>
++#include <stdlib.h>
++#include <errno.h> /* For strerror and errno */
++
+ 
+ /* WAV format is little-endian... */
+ static uint32 file_length;


### PR DESCRIPTION
**Description:**

This PR aims to add MIDI playback support to the Heroic Games Launcher Flatpak by integrating TiMidity++ (version 2.15.0) and the FluidR3_GM soundfont. The goal is to enable MIDI music for games launched via Heroic, particularly older titles that rely on MIDI. I wanted to implement my[ local fix.](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4409)

**What has been successfully implemented:**

- TiMidity++ version 2.15.0 has been added as a new module:
It is configured with --enable-alsa and --enable-alsaseq to support ALSA output, including the ALSA sequencer interface.
- The FluidR3_GM soundfont is included as a separate module (fluidr3-soundfont).
- A series of patches have been created and applied to the TiMidity++ 2.15.0 source code. These patches address numerous "implicit function declaration" errors, allowing TiMidity++ to compile successfully with the modern compilers in the Freedesktop SDK 24.08. The patched files include au_a.c, freq.c, output.c, quantity.c, raw_a.c, timidity.c, and wave_a.c.
- An inline configuration file (custom-timidity.cfg) is created and installed to /app/share/timidity/timidity.cfg within the sandbox. This file directs TiMidity++ to use the included FluidR3_GM soundfont located at /app/share/soundfonts/.
- The Flatpak manifest (com.heroicgameslauncher.hgl.yml) builds successfully with these additions.

**Current Status & Known Issue:**

Despite successful compilation, packaging, and configuration file placement, TiMidity++ currently fails to initialize ALSA output devices at runtime when executed inside the Flatpak sandbox.

- The primary error observed when attempting to run timidity (e.g., timidity -iA -Os --verbose &, timidity -Ov --verbose &, or even just timidity some_midi_file.mid) inside the sandbox is: Couldn't open output device
- This is often preceded or accompanied by messages like Playmode 's' is not compiled in. (or similar, depending on the flags used), which appears to be a secondary symptom of the failure to open an audio device.
- This failure occurs even when attempting to direct output to the pulse ALSA device (timidity -Opulse --verbose &).
- The host system used for testing runs Fedora with PipeWire 1.4.2 managing audio. The Flatpak is built against the Freedesktop SDK 24.08.

**Further Investigation Needed:**

The current evidence suggests an issue with how the sandboxed TiMidity++ (using the SDK's alsa-lib) interacts with the host's PipeWire-emulated ALSA environment through the Flatpak ALSA portal. Further investigation is required to make TiMidity++ functional for MIDI output. Potential areas to explore include:

- Using tools like strace on the timidity process inside the sandbox to identify precisely which ALSA calls are failing or what resources it's unable to access.
- Exploring if different or additional configure flags for TiMidity++'s ALSA backend are necessary for better compatibility within this specific sandboxed PipeWire environment.
- Investigating if specific ALSA plugins, environment variables, or configurations are missing or misconfigured within the Flatpak sandbox that TiMidity++ might require.
- Considering if an alternative, perhaps more modern, MIDI synthesizer might offer better out-of-the-box compatibility with the Flatpak sandbox and PipeWire.