### PR TITLE
Refresh flatpak internal depends to latest versions.

### DIFF
--- a/com.heroicgameslauncher.hgl.metainfo.xml
+++ b/com.heroicgameslauncher.hgl.metainfo.xml
@@ -158,13 +158,6 @@
     <p xml:lang="zh">Flatpak 的当前限制：</p>
     <p xml:lang="ja">Flatpak の現在の制限：</p>
     <ul>
-      <li>Due to issues with controller on SteamDeck Gaming Mode Heroic uses Flatpak Runtime 23.08 on stable branch. If you need runtime 24.08 to have HDR support and more please use the beta branch of flathub.</li>
-      <li xml:lang="de">Aufgrund von Problemen mit Controllern im SteamDeck Gaming Mode verwendet Heroic auf dem Stable Branch Flatpak Runtime 23.08. Wenn du Runtime 24.08 für HDR Support und mehr benötigst, nutze bitte den Beta Branch von Flathub.</li>
-      <li xml:lang="pt">Devido a problemas com o controle no modo de jogo SteamDeck, o Heroic usa o Flatpak Runtime 23.08 no branch estável. Se você precisar do runtime 24.08 para ter suporte a HDR e mais, use o branch beta do Flathub.</li>
-      <li xml:lang="es">Debido a problemas con el controlador en el modo de juego SteamDeck, Heroic utiliza Flatpak Runtime 23.08 en la rama estable. Si necesitas runtime 24.08 para tener soporte HDR y más, utiliza la rama beta de Flathub.</li>
-      <li xml:lang="fr">En raison de problèmes de contrôleur en mode jeu SteamDeck, Heroic utilise Flatpak Runtime 23.08 sur la branche stable. Si vous avez besoin de la runtime 24.08 pour bénéficier du support HDR et plus encore, veuillez utiliser la branche bêta de Flathub.</li>
-      <li xml:lang="zh">由于 SteamDeck 游戏模式下控制器的问题，Heroic 在稳定分支上使用 Flatpak Runtime 23.08。如果您需要运行时 24.08 来支持 HDR 等功能，请使用 Flathub 的 beta 分支。</li>
-      <li xml:lang="ja">SteamDeck ゲーミングモードでのコントローラーの問題により、Heroic は安定ブランチで Flatpak Runtime 23.08 を使用しています。HDR サポートなどのために Runtime 24.08 が必要な場合は、Flathub のベータブランチを使用してください。</li>
       <li>Heroic will not find or use Wine and Proton Flatpak versions. At least for now.</li>
       <li xml:lang="de">Heroic findet aktuell keine Wine oder Proton Versionen, die per Flatpak installiert
         sind</li>
@@ -177,7 +170,7 @@
       <li xml:lang="de">Heroic sollte Proton Versionen von Steam (Nativ und Flatpak) finden, sofern sie
         innerhalb der Bibliothek des Benutzerordners installiert sind.</li>
       <li>Heroic cannot access /usr/bin so it won&apos;t be able to find any wine or proton
-        isntalled there for now.</li>
+        installed there for now.</li>
       <li xml:lang="de">Heroic hat keinen Zugriff auf /usr/bin, weshalb es dort installierte Wine oder
         Proton Versionen nicht finden kann.</li>
     </ul>
@@ -261,3 +254,4 @@
     <keyword>amazon prime games launcher</keyword>
   </keywords>
 </component>
+

--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -1,71 +1,61 @@
 id: com.heroicgameslauncher.hgl
-sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime-version: &runtime-version '25.08'
+x-runtime-version-extra: &runtime-version-extra 25.08-extra
+x-gl-version: &gl-version '1.4'
+x-gl-versions: &gl-versions 25.08;25.08-extra;1.4
+x-gl-merge-dirs: &gl-merge-dirs vulkan/icd.d;glvnd/egl_vendor.d;egl/egl_external_platform.d;OpenCL/vendors;lib/dri;lib/d3d;lib/gbm;vulkan/explicit_layer.d;vulkan/implicit_layer.d;vdpau
+sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '25.08'
+base-version: *runtime-version
 command: heroic-run
 separate-locales: false
 
 cleanup:
-  - /share/docs
+  - /include
+  - /lib/*.a
+  - /lib/*.la
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /lib32/*.a
+  - /lib32/*.la
+  - /lib32/pkgconfig
+  - /share/doc
+  - /share/gtk-doc
   - /share/man
+  - /share/pkgconfig
+  - /share/docs
 
 sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
 
 finish-args:
-  - --allow=devel
-  - --allow=multiarch
-  - --allow=bluetooth
-
-  # pressure vessel
-  - --allow=per-app-dev-shm
-  - --device=all
-  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin:/usr/lib/extensions/vulkan/gamescope/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin:/app/bin/heroic/resources/app.asar.unpacked/build/bin/linux
-  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
-  - --filesystem=~/.local/share/lutris:rw
-  - --filesystem=~/.steam/steam:rw
-  - --filesystem=~/.local/share/applications:rw
-  - --filesystem=~/.steam:rw
-  - --filesystem=~/Games/Heroic:create
-  - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-desktop
-  - --filesystem=xdg-run/gamescope-0:rw
-  # should fix access to SD card on the deck
-  - --filesystem=/run/media
-  # There are still quite a few users using /mnt/ and /media/ for external drives
-  - --filesystem=/mnt
-  - --filesystem=/media
-  # should fix steamdeck controler navigation
-  - --filesystem=/run/udev:ro
-  # should fix discord rich presence
-  - --filesystem=xdg-run/app/com.discordapp.Discord:create
-  # umu
-  - --filesystem=xdg-data/umu:create
-  - --filesystem=xdg-config/MangoHud:ro
-  - --persist=.
+# Copied from flathub's Steam: https://github.com/flathub/com.valvesoftware.Steam
   - --share=ipc
-  - --share=network
-  - --socket=x11
   - --socket=wayland
+  - --socket=x11
   - --socket=pulseaudio
-  - --talk-name=org.kde.StatusNotifierWatcher
-  - --talk-name=com.canonical.Unity
-  - --talk-name=org.freedesktop.ScreenSaver
-
-  # copied from steam (wip)
-  # wine uses this for disk drives (mountmgr.sys)
-  - --system-talk-name=org.freedesktop.UDisks2
+  - --share=network
+#  - --own-name=com.steampowered.*
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
   # Wine uses UDisks2 to enumerate disk drives
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.UPower
+  - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.Notifications
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-pictures:ro
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/pipewire-0:ro
+  - --device=all
+  - --allow=multiarch
+  - --allow=devel
+  - --allow=bluetooth
+  - --allow=per-app-dev-shm
+  - --persist=.
   - --env=TZ=
   - --unset-env=TZ
   - --env=LC_ADDRESS=C
@@ -86,52 +76,97 @@ finish-args:
   - --env=SDL_VIDEODRIVER=
   - --unset-env=SDL_VIDEODRIVER
   - --env=DBUS_FATAL_WARNINGS=0
+  - --env=SSL_CERT_DIR=/etc/ssl/certs
+  - --env=PYTHONPATH=/app/utils/lib/python3.13/site-packages
   - --env=PROTON_DEBUG_DIR=/var/tmp
   - --env=XDG_CONFIG_DIRS=/etc/xdg:/usr/lib/x86_64-linux-gnu/GL:/usr/lib/i386-linux-gnu/GL
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
-  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
+  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/codecs-extra/lib/gstreamer-1.0:/usr/lib/i386-linux-gnu/codecs-extra/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
+  
+# Unique to Heroic
+  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin:/usr/lib/extensions/vulkan/gamescope/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin:/app/bin/heroic/resources/app.asar.unpacked/build/bin/linux
+  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
+  - --filesystem=~/.local/share/lutris
+  - --filesystem=~/.steam/steam
+  - --filesystem=~/.local/share/applications
+  - --filesystem=~/.steam
+  - --filesystem=~/Games/Heroic:create
+  - --filesystem=~/.var/app/com.valvesoftware.Steam
+  - --filesystem=xdg-desktop
+  - --filesystem=xdg-run/gamescope-0
+  - --filesystem=~/snap/steam
+  - --filesystem=~/.snap/data/steam  # For 'experimental.hidden-snap-folder'
+  # should fix access to SD card on the deck
+  - --filesystem=/run/media
+  # There are still quite a few users using /mnt/ and /media/ for external drives
+  - --filesystem=/mnt
+  - --filesystem=/media
+  # should fix steamdeck controler navigation
+  - --filesystem=/run/udev:ro
+  # umu
+  - --filesystem=xdg-data/umu:create
+  - --filesystem=xdg-config/MangoHud:ro
+  - --talk-name=com.canonical.Unity
 
 add-extensions:
+# Copied from flathub's Steam: https://github.com/flathub/com.valvesoftware.Steam
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '25.08'
+    version: *runtime-version
 
   org.freedesktop.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: '25.08'
+    version: *runtime-version
     no-autodownload: true
 
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
-    version: '1.4'
-    versions: 25.08;1.4
+    version: *gl-version
+    versions: *gl-versions
     subdirectories: true
     no-autodownload: true
     autodelete: false
     add-ld-path: lib
-    merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
+    merge-dirs: *gl-merge-dirs
     download-if: active-gl-driver
     enable-if: active-gl-driver
     autoprune-unless: active-gl-driver
 
-  x-compat-i386-opts: &compat_i386_opts
-    prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
-    ldflags: -L/app/lib32
-    append-path: /usr/lib/sdk/toolchain-i386/bin
-    env:
-      CC: i686-unknown-linux-gnu-gcc
-      CXX: i686-unknown-linux-gnu-g++
-    libdir: /app/lib32
+  org.freedesktop.Platform.GL32.Debug:
+    directory: lib/debug/lib/i386-linux-gnu/GL
+    version: *gl-version
+    versions: *gl-versions
+    subdirectories: true
+    no-autodownload: true
+    merge-dirs: *gl-merge-dirs
+    enable-if: active-gl-driver
+    autoprune-unless: active-gl-driver
 
   org.freedesktop.Platform.VAAPI.Intel.i386:
     directory: lib/i386-linux-gnu/dri/intel-vaapi-driver
-    version: '25.08'
-    versions: '25.08'
+    version: *runtime-version
+    versions: *runtime-version
     autodelete: false
     no-autodownload: true
     add-ld-path: lib
     download-if: have-intel-gpu
     autoprune-unless: have-intel-gpu
+
+  org.freedesktop.Platform.VAAPI.nvidia.i386:
+    directory: i386/nvidia-vaapi-driver
+    version: *runtime-version
+    versions: *runtime-version
+    autodelete: false
+    no-autodownload: true
+    add-ld-path: lib
+    download-if: have-kernel-module-nvidia
+    autoprune-unless: have-kernel-module-nvidia
+
+  org.freedesktop.Platform.codecs_extra.i386:
+    directory: lib/i386-linux-gnu/codecs-extra
+    version: *runtime-version-extra
+    autodelete: false
+    add-ld-path: lib
 
   com.valvesoftware.Steam.Utility:
     subdirectories: true
@@ -139,84 +174,13 @@ add-extensions:
     version: stable
     versions: stable;beta;test
     add-ld-path: lib
-    merge-dirs: bin
+    merge-dirs: bin;lib/python3.13/site-packages;share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;share/steam/compatibilitytools.d;
     no-autodownload: true
     autodelete: true
 
 modules:
-  # --- Tools ---
-  - name: vulkan-tools
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DGLSLANG_INSTALL_DIR=/app
-      - -DVULKAN_HEADERS_INSTALL_DIR=/app
-      - -DCMAKE_BUILD_TYPE=Release
-    sources:
-      - type: archive
-        url: https://github.com/KhronosGroup/Vulkan-Tools/archive/v1.3.297/Vulkan-Tools-1.3.297.tar.gz
-        sha256: 95bffa39d90f3ec81d8e3a0fa6c846ac1a10442152cc0b6d0d6567ce48932f89
-    modules:
-      - name: volk
-        buildsystem: cmake-ninja
-        config-opts:
-          - -DVOLK_INSTALL=ON
-        sources:
-          - type: archive
-            url: https://github.com/zeux/volk/archive/vulkan-sdk-1.3.296.0.tar.gz
-            sha256: 8ffd0e81e29688f4abaa39e598937160b098228f37503903b10d481d4862ab85
-        modules:
-          - name: vulkan-headers
-            buildsystem: cmake-ninja
-            sources:
-              - type: archive
-                url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.297/Vulkan-Headers-v1.3.297.tar.gz
-                sha256: 1d679e2edc43cb7ad818b81dea960e374f1d6dd082325eb9b4c6113e76263c02
-
-  - name: gamemode
-    buildsystem: meson
-    config-opts: &gamemode_opts
-      - -Dwith-examples=false
-      - -Dwith-util=false
-      - -Dwith-sd-bus-provider=no-daemon
-    sources: &gamemode_sources
-      - type: git
-        url: https://github.com/FeralInteractive/gamemode.git
-        tag: 1.8.2
-        commit: c54d6d4243b0dd0afcb49f2c9836d432da171a2b
-        x-checker-data:
-          type: git
-
-  - name: gamemode-32bit
-    build-options:
-      arch:
-        x86_64: *compat_i386_opts
-    buildsystem: meson
-    config-opts: *gamemode_opts
-    sources: *gamemode_sources
-
-  - name: gamemoderun
-    buildsystem: simple
-    build-commands:
-      - install -Dm755 data/gamemoderun -t /app/bin
-    sources: *gamemode_sources
-
-  - name: rsync
-    config-opts:
-      - --prefix=${FLATPAK_DEST}
-      - --with-included-popt
-      - --with-included-zlib
-      - --host=x86
-      - --disable-xxhash
-      - --disable-md2man
-    sources:
-      - type: archive
-        url: https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz
-        sha256: 2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52
-        x-checker-data:
-          type: anitya
-          project-id: 4217
-          stable-only: true
-          url-template: https://download.samba.org/pub/rsync/src/rsync-$version.tar.gz
+  - modules.yml
+  - modules-32bit.yml
 
   # --- Heroic ---
   - name: heroic
@@ -247,243 +211,41 @@ modules:
       - |
         set -e
         mkdir -p /app/bin
-        mkdir -p /app/utils
         mkdir -p /app/lib/i386-linux-gnu
-        mkdir -p /app/lib/debug/lib/i386-linux-gnu
         mkdir -p /app/lib/i386-linux-gnu/GL
         mkdir -p /app/lib/i386-linux-gnu/dri/intel-vaapi-driver
+        mkdir -p /app/i386/nvidia-vaapi-driver
+        mkdir -p /app/lib/i386-linux-gnu/codecs-extra
+        mkdir -p /app/lib/debug/lib/i386-linux-gnu
+        mkdir -p /app/lib/debug/lib/i386-linux-gnu/GL
+        cp /usr/bin/addr2line /app/bin/
+        cp /usr/lib/x86_64-linux-gnu/libbfd-*.so /app/lib/
+        install -Dm644 -t /app/etc ld.so.conf
+        mkdir -p /app/share/steam/compatibilitytools.d
+        mkdir -p /app/utils /app/share/vulkan
+        ln -srv /app/{utils/,}share/vulkan/explicit_layer.d
+        ln -srv /app/{utils/,}share/vulkan/implicit_layer.d
+        mkdir -p /app/links/lib
+        ln -srv /app/lib /app/links/lib/x86_64-linux-gnu
+        ln -srv /app/lib32 /app/links/lib/i386-linux-gnu
+        mkdir -p /app/utils
         install -Dm644 com.heroicgameslauncher.hgl.png /app/share/icons/hicolor/128x128/apps/com.heroicgameslauncher.hgl.png
         install -Dm644 com.heroicgameslauncher.hgl.desktop /app/share/applications/${FLATPAK_ID}.desktop
-        install -Dm644 -t /app/etc ld.so.conf
         install -Dm644 $FLATPAK_ID.metainfo.xml /app/share/metainfo/$FLATPAK_ID.appdata.xml
     sources:
       - type: inline
         dest-filename: ld.so.conf
         contents: |
+          include /run/flatpak/ld.so.conf.d/app-*-org.freedesktop.Platform.GL32.*.conf
           /app/lib32
           /app/lib/i386-linux-gnu
+          /usr/lib/i386-linux-gnu
+          /app/lib
+          /usr/lib/x86_64-linux-gnu
+          /lib64
       - type: file
         path: com.heroicgameslauncher.hgl.metainfo.xml
       - type: file
         path: com.heroicgameslauncher.hgl.png
       - type: file
         path: com.heroicgameslauncher.hgl.desktop
-
-  #START --- Winetricks Deps ---
-  - name: 7zip
-    buildsystem: simple
-    subdir: CPP/7zip/Bundles/Alone2
-    build-commands:
-      - make -j $FLATPAK_BUILDER_N_JOBS -f makefile.gcc
-      - install -Dm755 ./_o/7zz -t /app/bin
-      - ln -s /app/bin/7zz /app/bin/7za
-      - ln -s /app/bin/7zz /app/bin/7z
-    sources:
-      - type: archive
-        url: https://github.com/ip7z/7zip/archive/refs/tags/26.00.tar.gz
-        sha256: 07eafed75d661282d402dc2a3edf17e1dbb36fb813f4fbf5a2bad4f6b722aed5
-        x-checker-data:
-          type: anitya
-          project-id: 372314
-          url-template: https://github.com/ip7z/7zip/archive/refs/tags/$version.tar.gz
-
-  - name: cabextract
-    build-options:
-      strip: true
-    sources:
-      - type: archive
-        url: https://www.cabextract.org.uk/cabextract-1.11.tar.gz
-        sha256: b5546db1155e4c718ff3d4b278573604f30dd64c3c5bfd4657cd089b823a3ac6
-        x-checker-data:
-          type: anitya
-          project-id: 245
-          url-template: https://www.cabextract.org.uk/cabextract-$version.tar.gz
-
-  - name: unrar
-    no-autogen: true
-    build-options:
-      strip: true
-    make-install-args:
-      - DESTDIR=$(FLATPAK_DEST)
-    sources:
-      - type: archive
-        url: https://www.rarlab.com/rar/unrarsrc-7.2.5.tar.gz
-        sha256: 3d7b402ce7b9825af32a5f593379269e742c883d9d276527be19d0e9f6a114f9
-        x-checker-data:
-          type: anitya
-          project-id: 13306
-          url-template: https://www.rarlab.com/rar/unrarsrc-$version.tar.gz
-
-  - name: binutils-ar
-    buildsystem: simple
-    build-options:
-      strip: true
-    build-commands:
-      - install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin/
-      - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib/
-
-  - name: aria2
-    config-opts:
-      - --disable-libaria2
-      - --disable-websocket
-      - --without-sqlite3
-    sources:
-      - type: archive
-        sha256: 60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b
-        url: https://github.com/aria2/aria2/releases/download/release-1.37.0/aria2-1.37.0.tar.xz
-
-  - name: libcaca
-    config-opts: &libcaca_config_opts
-      - --disable-doc
-      - --disable-python
-      - --disable-ruby
-      - --disable-static
-    sources: &libcaca_sources
-      - type: archive
-        url: http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz
-        sha256: 128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4
-
-  - name: libcaca-32bit
-    build-options:
-      arch:
-        x86_64: *compat_i386_opts
-    config-opts: *libcaca_config_opts
-    sources: *libcaca_sources
-
-  - name: libbsd
-    sources: &libbsd_sources
-      - type: archive
-        url: https://libbsd.freedesktop.org/releases/libbsd-0.10.0.tar.xz
-        sha256: 34b8adc726883d0e85b3118fa13605e179a62b31ba51f676136ecb2d0bc1a887
-
-  - name: libbsd-32bit
-    build-options:
-      arch:
-        x86_64: *compat_i386_opts
-    sources: *libbsd_sources
-  #END --- Winetricks Deps ---
-
-  # --- MIDI Support (TiMidity++ with FluidR3_GM) ---
-  - name: timidity
-    buildsystem: autotools
-    build-options:
-      cflags: -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration
-    config-opts:
-      - --enable-alsa
-      - --enable-alsaseq
-      - --enable-audio=alsa,pulse
-      - --enable-interface=server,alsaseq
-    cleanup: ['*.la', '*.a', /include, /lib/pkgconfig, /share/man, /share/doc]
-
-    sources:
-      - type: archive
-        url: https://sourceforge.net/projects/timidity/files/TiMidity++/TiMidity++-2.15.0/TiMidity++-2.15.0.tar.bz2
-        sha256: 161fc0395af16b51f7117ad007c3e434c825a308fa29ad44b626ee8f9bb1c8f5
-      - type: shell
-        commands:
-          - sed -i '/int line_fold();/d' utils/nkflib.c
-      - type: inline
-        dest-filename: custom-timidity.cfg
-        contents: |
-          dir /app/share/soundfonts
-          source /app/share/soundfonts/fluid3gm.cfg
-          opt EFresamp=d
-          opt EFvlpf=d
-          opt EFreverb=d
-      - type: patch
-        path: patches/0001-timidity-fix-missing-includes.patch
-      - type: inline
-        dest-filename: heroic-midi-wrapper
-        contents: |
-          #!/bin/bash
-
-          detect_midi_game() {
-            local game_dir="$1"
-            if [[ ! -d "$game_dir" ]]; then return 1; fi
-            if find "$game_dir" -iname "*.mid" -o -iname "*.midi" | grep -q .; then
-              echo "Found MIDI files in game directory"
-              return 0
-            fi
-            if find "$game_dir" -name "*.cfg" -o -name "*.conf" -o -name "*.ini" | \
-              xargs grep -l -i "midi\|timidity\|mpu-401\|sound.*midi" 2>/dev/null | grep -q .; then
-              echo "Found MIDI configuration references"  
-              return 0
-            fi
-            return 1
-          }
-
-          start_timidity() {
-            if ! pgrep -f "timidity.*-iA" > /dev/null; then
-              echo "Auto-starting TiMidity++ for MIDI-enabled game"
-              /app/bin/timidity -iA &
-              TIMIDITY_PID=$!
-              sleep 2
-              echo "TiMidity++ ready for MIDI playback"
-            fi
-          }
-
-          cleanup() {
-            if [[ -n "$TIMIDITY_PID" ]] && kill -0 "$TIMIDITY_PID" 2>/dev/null; then
-              echo "Stopping TiMidity++ (PID: $TIMIDITY_PID)"
-              kill "$TIMIDITY_PID" 2>/dev/null
-            fi
-          }
-
-          trap cleanup EXIT INT TERM
-
-          if [[ -n "$STEAM_COMPAT_INSTALL_PATH" ]]; then
-            if detect_midi_game "$STEAM_COMPAT_INSTALL_PATH"; then
-              start_timidity
-            fi
-          fi
-
-          /app/bin/gamemoderun-original "$@" &
-          GAME_PID=$!
-
-          wait $GAME_PID
-          GAME_EXIT_CODE=$?
-
-          cleanup
-          exit $GAME_EXIT_CODE
-
-    post-install:
-      - install -d ${FLATPAK_DEST}/share/timidity
-      - install -Dm644 custom-timidity.cfg ${FLATPAK_DEST}/share/timidity/timidity.cfg
-      - mv ${FLATPAK_DEST}/bin/gamemoderun ${FLATPAK_DEST}/bin/gamemoderun-original
-      - install -Dm755 heroic-midi-wrapper ${FLATPAK_DEST}/bin/gamemoderun
-
-      # Copy ALSA configuration files
-      - install -d ${FLATPAK_DEST}/share/alsa
-      - cp -ar /usr/share/alsa/* ${FLATPAK_DEST}/share/alsa/
-      - install -d ${FLATPAK_DEST}/etc
-      - ln -sf /app/share/alsa/alsa.conf ${FLATPAK_DEST}/etc/asound.conf
-
-        # Copy ALSA plugins (both x86_62 and i386 for multilib support)
-      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib
-      - cp -a /usr/lib/x86_64-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib/
-      - install -d ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib
-      - cp -a /usr/lib/i386-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib/
-
-        # Copy PulseAudio client libraries
-      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu
-      - cp -a /usr/lib/x86_64-linux-gnu/libpulse.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libsndfile.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libogg.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libvorbis*.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libFLAC.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - cp -a /usr/lib/x86_64-linux-gnu/libopus.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
-      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio
-      - cp -a /usr/lib/x86_64-linux-gnu/pulseaudio/libpulsecommon*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio/
-
-  - name: fluidr3-soundfont
-    buildsystem: simple
-    build-commands:
-      - tar -xzf fluid-soundfont.tar.gz -C . "FluidR3 GM2-2.SF2"
-      - install -d ${FLATPAK_DEST}/share/soundfonts
-      - install -Dm644 "FluidR3 GM2-2.SF2" ${FLATPAK_DEST}/share/soundfonts/FluidR3_GM.sf2
-      - echo "soundfont FluidR3_GM.sf2" > fluid3gm.cfg
-      - install -Dm644 fluid3gm.cfg ${FLATPAK_DEST}/share/soundfonts/fluid3gm.cfg
-    sources:
-      - type: file
-        url: https://ftp.osuosl.org/pub/musescore/soundfont/fluid-soundfont.tar.gz
-        sha256: c815769e44d86f1507b946a6c48c997c7f650699aea1ec4b11ba66e3415c26b9

--- a/modules-32bit.yml
+++ b/modules-32bit.yml
@@ -1,0 +1,30 @@
+x-compat-i386-opts: &compat_i386_opts
+  prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
+  ldflags: -L/app/lib32 -Wl,-rpath-link=/app/lib32 -Wl,-z,relro,-z,now -Wl,--as-needed
+  ldflags-override: true
+  prepend-path: /usr/lib/sdk/toolchain-i386/bin
+  env:
+    CC: i686-unknown-linux-gnu-gcc
+    CXX: i686-unknown-linux-gnu-g++
+  libdir: /app/lib32
+
+name: modules-32bit
+buildsystem: simple
+build-commands: []
+modules:
+
+    - name: gamemode-32bit
+      build-options:
+        arch:
+          x86_64: *compat_i386_opts
+      buildsystem: meson
+      config-opts:
+        - -Dwith-examples=false
+        - -Dwith-util=false
+        - -Dwith-sd-bus-provider=no-daemon
+      sources:
+        - type: git
+          url: https://github.com/FeralInteractive/gamemode.git
+          commit: f0a569a5199974751a4a75ebdc41c8f0b8e4c909
+          x-checker-data:
+            type: git

--- a/modules.yml
+++ b/modules.yml
@@ -1,0 +1,365 @@
+name: modules
+buildsystem: simple
+build-commands: []
+modules:
+
+  - name: zlib-ng
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DZLIB_ENABLE_TESTS=false
+      - -DZLIB_COMPAT=true
+    sources:
+      - type: archive
+        url: https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.3.3.tar.gz
+        sha256: f9c65aa9c852eb8255b636fd9f07ce1c406f061ec19a2e7d508b318ca0c907d1
+        x-checker-data:
+          type: anitya
+          project-id: 115592
+          url-template: https://github.com/zlib-ng/zlib-ng/archive/refs/tags/$version.tar.gz
+
+# -- controllers --
+
+  - name: hwdata
+    config-opts:
+      - --datarootdir=/app/share
+    sources:
+      - type: git
+        url: https://github.com/vcrhonek/hwdata
+        tag: v0.406
+        commit: 9ae3b9da5cbb93eed30f812aa7edb4b9ad3e3868
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/vcrhonek/hwdata/releases/latest
+          tag-query: .tag_name
+
+  - name: usbutils
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/gregkh/usbutils
+        commit: d0c76b601b4b3ab9b2ab2647d604a8e3cce6d666
+        tag: v019
+        x-checker-data:
+          type: anitya
+          project-id: 5061
+          stable-only: true
+          tag-template: v$version
+
+  - name: lsof
+    buildsystem: simple
+    build-commands:
+      - ./Configure -n linux
+      - make CC="cc ${CFLAGS} ${CPPFLAGS} ${LDFLAGS}"
+      - install -Dm755 lsof -t ${FLATPAK_DEST}/bin
+    sources:
+      - type: git
+        url: https://github.com/lsof-org/lsof
+        commit: b173315c8f94bf61d52094857ea3fe7d0f5aaff9
+        tag: 4.99.6
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/lsof-org/lsof/releases/latest
+          tag-query: .tag_name
+
+# -- end controllers --
+
+  - name: xrandr
+    sources:
+      - type: archive
+        url: https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.4.tar.xz
+        sha256: 2cafccb2aaf2491a4068676117a0d4f90ab307724b96fffc54cd1da953779400
+        x-checker-data:
+          type: anitya
+          project-id: 14957
+          stable-only: true
+          url-template: https://xorg.freedesktop.org/archive/individual/app/xrandr-$version.tar.xz
+
+  - name: libmd
+    sources:
+      - type: archive
+        url: https://libbsd.freedesktop.org/releases/libmd-1.1.0.tar.xz
+        sha256: 1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332
+        x-checker-data:
+          type: anitya
+          project-id: 15525
+          stable-only: true
+          url-template: https://libbsd.freedesktop.org/releases/libmd-$version.tar.xz
+
+  - name: libbsd
+    sources:
+      - type: archive
+        url: https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz
+        sha256: b88cc9163d0c652aaf39a99991d974ddba1c3a9711db8f1b5838af2a14731014
+        x-checker-data:
+          type: anitya
+          project-id: 1567
+          stable-only: true
+          url-template: https://libbsd.freedesktop.org/releases/libbsd-$version.tar.xz
+
+#START --- Winetricks Deps ---
+  - name: 7zip
+    buildsystem: simple
+    subdir: CPP/7zip/Bundles/Alone2
+    build-commands:
+      - make -j $FLATPAK_BUILDER_N_JOBS -f makefile.gcc
+      - install -Dm755 ./_o/7zz -t ${FLATPAK_DEST}/bin
+      - ln -s ${FLATPAK_DEST}/bin/7zz ${FLATPAK_DEST}/bin/7za
+      - ln -s ${FLATPAK_DEST}/bin/7zz ${FLATPAK_DEST}/bin/7z
+    sources:
+      - type: archive
+        url: https://github.com/ip7z/7zip/archive/refs/tags/26.01.tar.gz
+        sha256: f4212b508641b3584f7089ab67bc0aba028c631f049b4dd603ff07853e72e749
+        x-checker-data:
+          type: anitya
+          project-id: 372314
+          url-template: https://github.com/ip7z/7zip/archive/refs/tags/$version.tar.gz
+
+  - name: cabextract
+    build-options:
+      strip: true
+    sources:
+      - type: archive
+        url: https://www.cabextract.org.uk/cabextract-1.11.tar.gz
+        sha256: b5546db1155e4c718ff3d4b278573604f30dd64c3c5bfd4657cd089b823a3ac6
+        x-checker-data:
+          type: anitya
+          project-id: 245
+          url-template: https://www.cabextract.org.uk/cabextract-$version.tar.gz
+
+  - name: unrar
+    no-autogen: true
+    build-options:
+      strip: true
+    make-install-args:
+      - DESTDIR=$(FLATPAK_DEST)
+    sources:
+      - type: archive
+        url: https://www.rarlab.com/rar/unrarsrc-7.2.6.tar.gz
+        sha256: d1afa67ef4121ebc5986815699e05db0ce8648499e5dca854f282a4c3f72c003
+        x-checker-data:
+          type: anitya
+          project-id: 13306
+          url-template: https://www.rarlab.com/rar/unrarsrc-$version.tar.gz
+
+  - name: binutils-ar
+    buildsystem: simple
+    build-options:
+      strip: true
+    build-commands:
+      - install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin/
+      - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib/
+
+  - name: aria2
+    config-opts:
+      - --disable-libaria2
+      - --disable-websocket
+      - --without-sqlite3
+    sources:
+      - type: archive
+        sha256: 60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b
+        url: https://github.com/aria2/aria2/releases/download/release-1.37.0/aria2-1.37.0.tar.xz
+
+  - name: libjpeg # with libjpeg.so.8
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_SKIP_RPATH:BOOL=YES
+      - -DENABLE_STATIC:BOOL=NO
+      - -DWITH_JPEG8:BOOL=YES
+      - -DCMAKE_INSTALL_LIBDIR=/app/lib # uses lib64 by default
+    sources:
+      - type: archive
+        url: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.90/libjpeg-turbo-3.1.90.tar.gz
+        sha256: 1d0e86ee45bf435dc57f8744763ba62410294b0f5312cb87962214ac1f7fb78b
+
+#END --- Winetricks Deps ---
+
+  - name: rsync
+    config-opts:
+      - --prefix=${FLATPAK_DEST}
+      - --with-included-popt
+      - --with-included-zlib
+      - --host=x86
+      - --disable-xxhash
+      - --disable-md2man
+    sources:
+      - type: archive
+        url: https://download.samba.org/pub/rsync/src/rsync-3.4.2.tar.gz
+        sha256: ff10aa2c151cd4b2dbbe6135126dbc854046113d2dfb49572a348233267eb315
+        x-checker-data:
+          type: anitya
+          project-id: 4217
+          stable-only: true
+          url-template: https://download.samba.org/pub/rsync/src/rsync-$version.tar.gz
+
+  - name: gamemode
+    buildsystem: meson
+    config-opts:
+      - -Dwith-examples=false
+      - -Dwith-util=false
+      - -Dwith-sd-bus-provider=no-daemon
+    sources: &gamemode_sources
+      - type: git
+        url: https://github.com/FeralInteractive/gamemode.git
+        commit: f0a569a5199974751a4a75ebdc41c8f0b8e4c909
+        x-checker-data:
+          type: git
+  
+  - name: gamemoderun
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 data/gamemoderun -t ${FLATPAK_DEST}/bin
+    sources: *gamemode_sources
+
+# --- Vulkan Tools ---
+  - name: vulkan-tools
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DVULKAN_HEADERS_INSTALL_DIR=/app
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: archive
+        url: https://github.com/KhronosGroup/Vulkan-Tools/archive/v1.4.350/Vulkan-Tools-1.4.350.tar.gz
+        sha256: c7c11c72549bf48d1e7190b7143f5710d576cd687eb2efc4a3ae9cdd77209a7b
+    modules:
+      - name: volk
+        buildsystem: cmake-ninja
+        config-opts:
+          - -DVOLK_INSTALL=ON
+        sources:
+          - type: archive
+            url: https://github.com/zeux/volk/archive/refs/tags/1.4.350.tar.gz
+            sha256: e47c6efe5294bb03729a976b385864bba5daf46ec60f0bdea11e1d1446345f9a
+        modules:
+          - name: vulkan-headers
+            buildsystem: cmake-ninja
+            sources:
+              - type: archive
+                url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.4.350/Vulkan-Headers-v1.4.350.tar.gz
+                sha256: 6dd105e5cc7ddab6e7b611ae2c1872740d1727557cc8bf9daf13d6de1e4b3999
+# --- end Tools ---
+
+# --- MIDI Support (TiMidity++ with FluidR3_GM) ---
+  - name: timidity
+    buildsystem: autotools
+    build-options:
+      cflags: -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration
+    config-opts:
+      - --enable-alsa
+      - --enable-alsaseq
+      - --enable-audio=alsa,pulse
+      - --enable-interface=server,alsaseq
+    cleanup: ['*.la', '*.a', /include, /lib/pkgconfig, /share/man, /share/doc]
+
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/timidity/files/TiMidity++/TiMidity++-2.15.0/TiMidity++-2.15.0.tar.bz2
+        sha256: 161fc0395af16b51f7117ad007c3e434c825a308fa29ad44b626ee8f9bb1c8f5
+      - type: shell
+        commands:
+          - sed -i '/int line_fold();/d' utils/nkflib.c
+      - type: inline
+        dest-filename: custom-timidity.cfg
+        contents: |
+          dir /app/share/soundfonts
+          source /app/share/soundfonts/fluid3gm.cfg
+          opt EFresamp=d
+          opt EFvlpf=d
+          opt EFreverb=d
+      - type: patch
+        path: patches/0001-timidity-fix-missing-includes.patch
+      - type: inline
+        dest-filename: heroic-midi-wrapper
+        contents: |
+          #!/bin/bash
+
+          detect_midi_game() {
+            local game_dir="$1"
+            if [[ ! -d "$game_dir" ]]; then return 1; fi
+            if find "$game_dir" -iname "*.mid" -o -iname "*.midi" | grep -q .; then
+              echo "Found MIDI files in game directory"
+              return 0
+            fi
+            if find "$game_dir" -name "*.cfg" -o -name "*.conf" -o -name "*.ini" | \
+              xargs grep -l -i "midi\|timidity\|mpu-401\|sound.*midi" 2>/dev/null | grep -q .; then
+              echo "Found MIDI configuration references"  
+              return 0
+            fi
+            return 1
+          }
+
+          start_timidity() {
+            if ! pgrep -f "timidity.*-iA" > /dev/null; then
+              echo "Auto-starting TiMidity++ for MIDI-enabled game"
+              ${FLATPAK_DEST}/bin/timidity -iA &
+              TIMIDITY_PID=$!
+              sleep 2
+              echo "TiMidity++ ready for MIDI playback"
+            fi
+          }
+
+          cleanup() {
+            if [[ -n "$TIMIDITY_PID" ]] && kill -0 "$TIMIDITY_PID" 2>/dev/null; then
+              echo "Stopping TiMidity++ (PID: $TIMIDITY_PID)"
+              kill "$TIMIDITY_PID" 2>/dev/null
+            fi
+          }
+
+          trap cleanup EXIT INT TERM
+
+          if [[ -n "$STEAM_COMPAT_INSTALL_PATH" ]]; then
+            if detect_midi_game "$STEAM_COMPAT_INSTALL_PATH"; then
+              start_timidity
+            fi
+          fi
+
+          ${FLATPAK_DEST}/bin/gamemoderun-original "$@" &
+          GAME_PID=$!
+
+          wait $GAME_PID
+          GAME_EXIT_CODE=$?
+
+          cleanup
+          exit $GAME_EXIT_CODE
+
+    post-install:
+      - install -d ${FLATPAK_DEST}/share/timidity
+      - install -Dm644 custom-timidity.cfg ${FLATPAK_DEST}/share/timidity/timidity.cfg
+      - mv ${FLATPAK_DEST}/bin/gamemoderun ${FLATPAK_DEST}/bin/gamemoderun-original
+      - install -Dm755 heroic-midi-wrapper ${FLATPAK_DEST}/bin/gamemoderun
+
+      # Copy ALSA configuration files
+      - install -d ${FLATPAK_DEST}/share/alsa
+      - cp -ar /usr/share/alsa/* ${FLATPAK_DEST}/share/alsa/
+      - install -d ${FLATPAK_DEST}/etc
+      - ln -sf /app/share/alsa/alsa.conf ${FLATPAK_DEST}/etc/asound.conf
+
+        # Copy ALSA plugins (both x86_62 and i386 for multilib support)
+      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib
+      - cp -a /usr/lib/x86_64-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/alsa-lib/
+      - install -d ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib
+      - cp -a /usr/lib/i386-linux-gnu/alsa-lib/*.so ${FLATPAK_DEST}/lib/i386-linux-gnu/alsa-lib/
+
+        # Copy PulseAudio client libraries
+      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu
+      - cp -a /usr/lib/x86_64-linux-gnu/libpulse.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libsndfile.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libogg.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libvorbis*.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libFLAC.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - cp -a /usr/lib/x86_64-linux-gnu/libopus.so* ${FLATPAK_DEST}/lib/x86_64-linux-gnu/
+      - install -d ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio
+      - cp -a /usr/lib/x86_64-linux-gnu/pulseaudio/libpulsecommon*.so ${FLATPAK_DEST}/lib/x86_64-linux-gnu/pulseaudio/
+
+  - name: fluidr3-soundfont
+    buildsystem: simple
+    build-commands:
+      - tar -xzf fluid-soundfont.tar.gz -C . "FluidR3 GM2-2.SF2"
+      - install -d ${FLATPAK_DEST}/share/soundfonts
+      - install -Dm644 "FluidR3 GM2-2.SF2" ${FLATPAK_DEST}/share/soundfonts/FluidR3_GM.sf2
+      - echo "soundfont FluidR3_GM.sf2" > fluid3gm.cfg
+      - install -Dm644 fluid3gm.cfg ${FLATPAK_DEST}/share/soundfonts/fluid3gm.cfg
+    sources:
+      - type: file
+        url: https://ftp.osuosl.org/pub/musescore/soundfont/fluid-soundfont.tar.gz
+        sha256: c815769e44d86f1507b946a6c48c997c7f650699aea1ec4b11ba66e3415c26b9
+# --- end MIDI Support ---


### PR DESCRIPTION
Notable changes are updates to gamemode, 7z, and vulkan-tools.

- gamemode set to current HEAD for optional improvements to AMD 3D cache and Nvidia powerstate logic
- 7z switched from hacked-up port to official CLI
- vulkan-tools updated to 1.4
- Added hwinfo and usb-utils to help controller support (notes in Steam flatpak)

Also restructures the yml to look more like the Steam file so that it is easier to merge changes in the future.