### PR TITLE
Replace `patch-desktop-filename` with `patch-electron-desktop-filename`

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -226,7 +226,7 @@ modules:
       - ./Heroic-*.AppImage --appimage-extract
       - mv squashfs-root /app/bin/heroic
       - install -D heroic-run -t /app/bin
-      - patch-desktop-filename ${FLATPAK_DEST}/bin/heroic/resources/app.asar
+      - patch-electron-desktop-filename ${FLATPAK_DEST}/bin/heroic/resources/app.asar
     sources:
       - type: script
         dest-filename: heroic-run


### PR DESCRIPTION
`patch-desktop-filename` is deprecated and will be removed in 26.08. It's replaced by `patch-electron-desktop-filename`. See flathub/org.electronjs.Electron2.BaseApp#65 for details.