### PR TITLE
Use git sources wherever possible, drop unnecessary dependencies

### DIFF
--- a/com.heroicgameslauncher.hgl.yml
+++ b/com.heroicgameslauncher.hgl.yml
@@ -23,7 +23,7 @@ finish-args:
   # pressure vessel
   - --allow=per-app-dev-shm
   - --device=all
-  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin:/usr/lib/extensions/vulkan/gamescope/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin:/app/bin/heroic/resources/app.asar.unpacked/build/bin/linux
+  - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin:/usr/lib/extensions/vulkan/gamescope/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin:/app/bin/heroic/resources/app.asar.unpacked/build/bin/linux
   - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
   - --filesystem=~/.local/share/lutris:rw
   - --filesystem=~/.steam/steam:rw
@@ -114,15 +114,6 @@ add-extensions:
     enable-if: active-gl-driver
     autoprune-unless: active-gl-driver
 
-  x-compat-i386-opts: &compat_i386_opts
-    prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
-    ldflags: -L/app/lib32
-    append-path: /usr/lib/sdk/toolchain-i386/bin
-    env:
-      CC: i686-unknown-linux-gnu-gcc
-      CXX: i686-unknown-linux-gnu-g++
-    libdir: /app/lib32
-
   org.freedesktop.Platform.VAAPI.Intel.i386:
     directory: lib/i386-linux-gnu/dri/intel-vaapi-driver
     version: '25.08'
@@ -133,72 +124,32 @@ add-extensions:
     download-if: have-intel-gpu
     autoprune-unless: have-intel-gpu
 
-  com.valvesoftware.Steam.Utility:
-    subdirectories: true
-    directory: utils
-    version: stable
-    versions: stable;beta;test
-    add-ld-path: lib
-    merge-dirs: bin
-    no-autodownload: true
-    autodelete: true
-
 modules:
   # --- Tools ---
   - name: vulkan-tools
     buildsystem: cmake-ninja
     config-opts:
-      - -DGLSLANG_INSTALL_DIR=/app
-      - -DVULKAN_HEADERS_INSTALL_DIR=/app
+      - -DVULKAN_HEADERS_INSTALL_DIR=/usr
       - -DCMAKE_BUILD_TYPE=Release
     sources:
-      - type: archive
-        url: https://github.com/KhronosGroup/Vulkan-Tools/archive/v1.3.297/Vulkan-Tools-1.3.297.tar.gz
-        sha256: 95bffa39d90f3ec81d8e3a0fa6c846ac1a10442152cc0b6d0d6567ce48932f89
-    modules:
-      - name: volk
-        buildsystem: cmake-ninja
-        config-opts:
-          - -DVOLK_INSTALL=ON
-        sources:
-          - type: archive
-            url: https://github.com/zeux/volk/archive/vulkan-sdk-1.3.296.0.tar.gz
-            sha256: 8ffd0e81e29688f4abaa39e598937160b098228f37503903b10d481d4862ab85
-        modules:
-          - name: vulkan-headers
-            buildsystem: cmake-ninja
-            sources:
-              - type: archive
-                url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.297/Vulkan-Headers-v1.3.297.tar.gz
-                sha256: 1d679e2edc43cb7ad818b81dea960e374f1d6dd082325eb9b4c6113e76263c02
-
-  - name: gamemode
-    buildsystem: meson
-    config-opts: &gamemode_opts
-      - -Dwith-examples=false
-      - -Dwith-util=false
-      - -Dwith-sd-bus-provider=no-daemon
-    sources: &gamemode_sources
       - type: git
-        url: https://github.com/FeralInteractive/gamemode.git
-        tag: 1.8.2
-        commit: c54d6d4243b0dd0afcb49f2c9836d432da171a2b
+        url: https://github.com/KhronosGroup/Vulkan-Tools.git
+        tag: v1.4.354
+        commit: ec6931a360d89d08f1c7578fa43958fb3829b10a
         x-checker-data:
           type: git
-
-  - name: gamemode-32bit
-    build-options:
-      arch:
-        x86_64: *compat_i386_opts
-    buildsystem: meson
-    config-opts: *gamemode_opts
-    sources: *gamemode_sources
-
-  - name: gamemoderun
-    buildsystem: simple
-    build-commands:
-      - install -Dm755 data/gamemoderun -t /app/bin
-    sources: *gamemode_sources
+          tag-pattern: ^v([\d.]+)$
+    modules:
+      - name: vulkan-headers
+        buildsystem: cmake-ninja
+        sources:
+          - type: git
+            url: https://github.com/KhronosGroup/Vulkan-Headers.git
+            tag: v1.4.354
+            commit: 01393c3df0e5285b54ee6527466513f9e614be94
+            x-checker-data:
+              type: git
+              tag-pattern: ^v([\d.]+)$
 
   - name: rsync
     config-opts:
@@ -209,14 +160,13 @@ modules:
       - --disable-xxhash
       - --disable-md2man
     sources:
-      - type: archive
-        url: https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz
-        sha256: 2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52
+      - type: git
+        url: https://github.com/RsyncProject/rsync.git
+        tag: v3.4.4
+        commit: f26f747b8017b321d3776becc69f330dd889fa21
         x-checker-data:
-          type: anitya
-          project-id: 4217
-          stable-only: true
-          url-template: https://download.samba.org/pub/rsync/src/rsync-$version.tar.gz
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   # --- Heroic ---
   - name: heroic
@@ -247,7 +197,6 @@ modules:
       - |
         set -e
         mkdir -p /app/bin
-        mkdir -p /app/utils
         mkdir -p /app/lib/i386-linux-gnu
         mkdir -p /app/lib/debug/lib/i386-linux-gnu
         mkdir -p /app/lib/i386-linux-gnu/GL
@@ -279,25 +228,34 @@ modules:
       - ln -s /app/bin/7zz /app/bin/7za
       - ln -s /app/bin/7zz /app/bin/7z
     sources:
-      - type: archive
-        url: https://github.com/ip7z/7zip/archive/refs/tags/26.00.tar.gz
-        sha256: 07eafed75d661282d402dc2a3edf17e1dbb36fb813f4fbf5a2bad4f6b722aed5
+      - type: git
+        url: https://github.com/ip7z/7zip.git
+        tag: 26.01
+        commit: 8c63d71ff886bda90c86db28466287f977374237
         x-checker-data:
-          type: anitya
-          project-id: 372314
-          url-template: https://github.com/ip7z/7zip/archive/refs/tags/$version.tar.gz
+          type: git
 
   - name: cabextract
+    buildsystem: simple
+    build-commands:
+      - autoreconf -I /usr/share/gettext/m4 || true
+      - aclocal -I /usr/share/gettext/m4
+      - automake --add-missing
+      - autoreconf -I /usr/share/gettext/m4
+      - ./configure --prefix $FLATPAK_DEST
+      - make
+      - make install
     build-options:
       strip: true
+    subdir: cabextract
     sources:
-      - type: archive
-        url: https://www.cabextract.org.uk/cabextract-1.11.tar.gz
-        sha256: b5546db1155e4c718ff3d4b278573604f30dd64c3c5bfd4657cd089b823a3ac6
+      - type: git
+        url: https://github.com/kyz/libmspack.git
+        tag: v1.11
+        commit: 305907723a4e7ab2018e58040059ffb5e77db837
         x-checker-data:
-          type: anitya
-          project-id: 245
-          url-template: https://www.cabextract.org.uk/cabextract-$version.tar.gz
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: unrar
     no-autogen: true
@@ -314,53 +272,6 @@ modules:
           project-id: 13306
           url-template: https://www.rarlab.com/rar/unrarsrc-$version.tar.gz
 
-  - name: binutils-ar
-    buildsystem: simple
-    build-options:
-      strip: true
-    build-commands:
-      - install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin/
-      - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib/
-
-  - name: aria2
-    config-opts:
-      - --disable-libaria2
-      - --disable-websocket
-      - --without-sqlite3
-    sources:
-      - type: archive
-        sha256: 60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b
-        url: https://github.com/aria2/aria2/releases/download/release-1.37.0/aria2-1.37.0.tar.xz
-
-  - name: libcaca
-    config-opts: &libcaca_config_opts
-      - --disable-doc
-      - --disable-python
-      - --disable-ruby
-      - --disable-static
-    sources: &libcaca_sources
-      - type: archive
-        url: http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz
-        sha256: 128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4
-
-  - name: libcaca-32bit
-    build-options:
-      arch:
-        x86_64: *compat_i386_opts
-    config-opts: *libcaca_config_opts
-    sources: *libcaca_sources
-
-  - name: libbsd
-    sources: &libbsd_sources
-      - type: archive
-        url: https://libbsd.freedesktop.org/releases/libbsd-0.10.0.tar.xz
-        sha256: 34b8adc726883d0e85b3118fa13605e179a62b31ba51f676136ecb2d0bc1a887
-
-  - name: libbsd-32bit
-    build-options:
-      arch:
-        x86_64: *compat_i386_opts
-    sources: *libbsd_sources
   #END --- Winetricks Deps ---
 
   # --- MIDI Support (TiMidity++ with FluidR3_GM) ---
@@ -437,7 +348,7 @@ modules:
             fi
           fi
 
-          /app/bin/gamemoderun-original "$@" &
+          /usr/bin/gamemoderun "$@" &
           GAME_PID=$!
 
           wait $GAME_PID
@@ -449,7 +360,6 @@ modules:
     post-install:
       - install -d ${FLATPAK_DEST}/share/timidity
       - install -Dm644 custom-timidity.cfg ${FLATPAK_DEST}/share/timidity/timidity.cfg
-      - mv ${FLATPAK_DEST}/bin/gamemoderun ${FLATPAK_DEST}/bin/gamemoderun-original
       - install -Dm755 heroic-midi-wrapper ${FLATPAK_DEST}/bin/gamemoderun
 
       # Copy ALSA configuration files


### PR DESCRIPTION
- Drop unused `/app/utils` directory
- Drop nonexistent `com.valvesoftware.Steam.Utility` extension (I initially thought this was for gamescope, but it still works fine without it)
- Pull `vulkan-tools` from Git
  - Drop unnecessary `volk` dependency
- Drop `gamemode` (it is pre-installed in the runtime we depend on)
- Pull `rsync` from Git
- Pull `7zip` from Git
- Pull `cabextract` from Git
  - Figuring out their build steps was a journey. If you have suggestions on improvements there, please let me know
- Drop unnecessary `binutils-ar`
  - Seems this was once needed for cabextract to build; Winetricks itself definitely does not use it
- Drop unnecessary `aria2`
  - Winetricks won't automatically use this, and will prefer `curl` and/or `wget`
- Drop unnecessary `libcaca` and `libbsd`
  - They were just not used at all, not sure why we had them